### PR TITLE
Release/v2.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     lsb-release \
     software-properties-common \
-  && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get -y upgrade
 
 RUN curl -LsS https://aka.ms/InstallAzureCLIDeb | bash \
-  && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN az extension add --name azure-devops
 
@@ -32,9 +32,7 @@ WORKDIR /azp
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
-    unzip \
-    apt-transport-https \
-    software-properties-common
+    unzip
 
 #install yq
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.40.7/yq_linux_amd64 \
@@ -58,8 +56,8 @@ RUN apt-get update \
 #install docker cli
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 RUN echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt-get update \
     && apt-get install -y docker-ce-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /azp
 
 
 ENV TARGETARCH=linux-x64
-ENV VSTS_AGENT_VERSION=3.232.3
+ENV VSTS_AGENT_VERSION=3.248.0
 
 
 # To make it easier for build and release pipelines to run apt-get,

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 The easiest and most effective method for creating and managing Azure DevOps agents on Kubernetes, without the need to spend time and effort wrestling with settings! Scale-out as much as is necessary and demolish them gracefully.
 
+## Compatibility Matrix
+
+The table presented below outlines the correspondence between Helm chart versions, Docker tags, and the Azure DevOps agent versions included within those Docker images.
+
+| Helm Version | Docker Tag | Agent Version |
+|--------------|------------|---------------|
+| 2.0.1        | 3.248.0    | 3.248.0       |
+| 2.0.0        | 3.232.3    | 3.232.3       |
+| 1.0.7        | 2.214.1    | 2.214.1       |
+
 ## Important Release Notes
 
 ### 2.0.1

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ The easiest and most effective method for creating and managing Azure DevOps age
 
 ## Important Release Notes
 
+### 2.0.1
+
+- :white_check_mark: [duplicate apt install command](https://github.com/btungut/azure-devops-agent-on-kubernetes/issues/16)
+- :white_check_mark: [yq download the latest version](https://github.com/btungut/azure-devops-agent-on-kubernetes/issues/22)
+- :white_check_mark: [Upgrade VSTS agent to 3.248.0](https://github.com/btungut/azure-devops-agent-on-kubernetes/issues/23)
+- :white_check_mark: Optimize the Dockerfile steps and add comment lines.
+
+
+
 ### 2.0.0
 
 - :white_check_mark: [ubuntu 20.04 based image](https://github.com/btungut/azure-devops-agent-on-kubernetes/issues/13)
@@ -108,7 +117,7 @@ helm delete {RELEASE-NAME}
 | Name                | Description                                           | Value                 |
 | ------------------- | ----------------------------------------------------- | --------------------- |
 | `image.repository`  | Azure DevOps agent image repository                           | `btungut/azure-devops-agent`       |
-| `image.tag`         | Azure DevOps agent image tag (immutable tags are recommended) | `3.232.3` |
+| `image.tag`         | Azure DevOps agent image tag (immutable tags are recommended) | `3.248.0` |
 | `image.pullPolicy`  | Azure DevOps agent image pull policy                          | `IfNotPresent`        |
 | `image.pullSecrets` | Azure DevOps agent image pull secrets                         | `[]`                  |
 | `replicaCount` | Replica count for deployment                        | `1`                  |

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: azure-devops-agent
 description: Dockerized build agent for Azure DevOps
 type: application
-version: 2.0.0
-appVersion: "3.232.3"
+version: 2.0.1
+appVersion: "3.248.0"
 keywords:
   - azure devops
   - build agent

--- a/chart/README.md
+++ b/chart/README.md
@@ -4,6 +4,15 @@ The easiest and most effective method for creating and managing Azure DevOps age
 
 ## Important Release Notes
 
+### 2.0.1
+
+- :white_check_mark: [duplicate apt install command](https://github.com/btungut/azure-devops-agent-on-kubernetes/issues/16)
+- :white_check_mark: [yq download the latest version](https://github.com/btungut/azure-devops-agent-on-kubernetes/issues/22)
+- :white_check_mark: [Upgrade VSTS agent to 3.248.0](https://github.com/btungut/azure-devops-agent-on-kubernetes/issues/23)
+- :white_check_mark: Optimize the Dockerfile steps and add comment lines.
+
+
+
 ### 2.0.0
 
 - :white_check_mark: [ubuntu 20.04 based image](https://github.com/btungut/azure-devops-agent-on-kubernetes/issues/13)
@@ -104,7 +113,7 @@ helm delete {RELEASE-NAME}
 | Name                | Description                                           | Value                 |
 | ------------------- | ----------------------------------------------------- | --------------------- |
 | `image.repository`  | Azure DevOps agent image repository                           | `btungut/azure-devops-agent`       |
-| `image.tag`         | Azure DevOps agent image tag (immutable tags are recommended) | `3.232.3` |
+| `image.tag`         | Azure DevOps agent image tag (immutable tags are recommended) | `3.248.0` |
 | `image.pullPolicy`  | Azure DevOps agent image pull policy                          | `IfNotPresent`        |
 | `image.pullSecrets` | Azure DevOps agent image pull secrets                         | `[]`                  |
 | `replicaCount` | Replica count for deployment                        | `1`                  |

--- a/chart/README.md
+++ b/chart/README.md
@@ -2,6 +2,16 @@
 
 The easiest and most effective method for creating and managing Azure DevOps agents on Kubernetes, without the need to spend time and effort wrestling with settings! Scale-out as much as is necessary and demolish them gracefully.
 
+## Compatibility Matrix
+
+The table presented below outlines the correspondence between Helm chart versions, Docker tags, and the Azure DevOps agent versions included within those Docker images.
+
+| Helm Version | Docker Tag | Agent Version |
+|--------------|------------|---------------|
+| 2.0.1        | 3.248.0    | 3.248.0       |
+| 2.0.0        | 3.232.3    | 3.232.3       |
+| 1.0.7        | 2.214.1    | 2.214.1       |
+
 ## Important Release Notes
 
 ### 2.0.1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -31,7 +31,7 @@ image:
   registry: docker.io
   repository: btungut/azure-devops-agent
   pullPolicy: IfNotPresent
-  tag: "3.232.3"
+  tag: "3.248.0"
   pullSecrets: []
 
 resources:

--- a/local-build.sh
+++ b/local-build.sh
@@ -4,4 +4,7 @@ set -euo pipefail
 REGISTRY="${REGISTRY:-btungut}"
 TAG="${TAG:-latest}"
 
-docker build ./src -f ./Dockerfile -t ${REGISTRY}/azure-devops-agent:${TAG}
+docker build ./src \
+    -f ./Dockerfile \
+    -t ${REGISTRY}/azure-devops-agent:${TAG} \
+    --progress=plain


### PR DESCRIPTION
This pull request includes several updates to the Dockerfile, README, and Helm chart files to improve the build process and documentation for the Azure DevOps agent on Kubernetes. The most important changes include the introduction of a compatibility matrix, optimization of Dockerfile steps, and updates to the Azure DevOps agent version.

### Dockerfile Improvements:
* Introduced `ARG_UBUNTU_BASE_IMAGE_TAG` to parameterize the Ubuntu base image version and set the default to "20.04".
* Updated the Dockerfile to download and install the latest version of `yq` and added comments for better readability.
* Added steps to download and extract the Azure DevOps Agent and updated the agent version to `3.248.0`.
* Removed duplicate `apt-get install` commands and optimized the order of installation steps.

### Documentation Updates:
* Added a compatibility matrix to the `README.md` and `chart/README.md` files, detailing the correspondence between Helm chart versions, Docker tags, and Azure DevOps agent versions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R29) [[2]](diffhunk://#diff-8c1b4e77ab2d1a243d157dead3e2bf25a6dbbfe0352e5ada6ca43086739e440cR5-R25)
* Updated the `image.tag` in the `README.md`, `chart/README.md`, and `chart/values.yaml` files to reflect the new Azure DevOps agent version `3.248.0`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111-R130) [[2]](diffhunk://#diff-8c1b4e77ab2d1a243d157dead3e2bf25a6dbbfe0352e5ada6ca43086739e440cL107-R126) [[3]](diffhunk://#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4L34-R34)

### Helm Chart Updates:
* Incremented the Helm chart version to `2.0.1` and updated the `appVersion` to `3.248.0`.

### Local Build Script:
* Modified the `local-build.sh` script to include the `--progress=plain` option for better build output visibility.