### PR TITLE
Add sidecar containers

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{ with .Values.sideContainers }}
+          {{ toYaml . | nindent 8 }}
+        {{ end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,7 +9,6 @@ agent:
   patSecretKey: "pat"
   # ---------- AUTH  ----------
 
-  
   # Server / organization url, e.g.: https://dev.azure.com/your-organization-name
   organizationUrl: ""
 
@@ -50,7 +49,6 @@ volumeMounts: []
   # - name: dockersock
   #   mountPath: "/var/run/docker.sock"
 
-
 serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
@@ -61,6 +59,23 @@ serviceAccount:
   automount: true
   # Annotations to add to the service account
   annotations: {}
+
+sideContainers:
+  # - name: sidecar
+  #   imagePullPolicy: Always
+  #   image: nginx:latest
+  #   securityContext:
+  #     privileged: true
+  #   env:
+  #     - name: POD_NAME
+  #       valueFrom:
+  #         fieldRef:
+  #           fieldPath: metadata.name
+  #     - name: POD_UID
+  #       valueFrom:
+  #         fieldRef:
+  #           fieldPath: metadata.uid
+
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
As we required to add sidecar containers to our AzureDevOps agents for VPN connection (this also could be any other stuff like fluentd). 
I added the fact to be able to add sidecar containers to deployment

You are free to change the name of the values file.

Waiting for the review