### PR TITLE
Feature add sideContainers support

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{ with .Values.sideContainers }}
+          {{ toYaml . | nindent 8 }}
+        {{ end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -28,9 +28,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{ with .Values.sideContainers }}
-          {{ toYaml . | nindent 8 }}
-        {{ end }}
+      {{ with .Values.sideContainers }}
+        {{ toYaml . | nindent 8 }}
+      {{ end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,7 +9,6 @@ agent:
   patSecretKey: "pat"
   # ---------- AUTH  ----------
 
-  
   # Server / organization url, e.g.: https://dev.azure.com/your-organization-name
   organizationUrl: ""
 
@@ -50,7 +49,6 @@ volumeMounts: []
   # - name: dockersock
   #   mountPath: "/var/run/docker.sock"
 
-
 serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
@@ -61,6 +59,23 @@ serviceAccount:
   automount: true
   # Annotations to add to the service account
   annotations: {}
+
+sideContainers:
+  # - name: sidecar
+  #   imagePullPolicy: Always
+  #   image: nginx:latest
+  #   securityContext:
+  #     privileged: true
+  #   env:
+  #     - name: POD_NAME
+  #       valueFrom:
+  #         fieldRef:
+  #           fieldPath: metadata.name
+  #     - name: POD_UID
+  #       valueFrom:
+  #         fieldRef:
+  #           fieldPath: metadata.uid
+
 
 nodeSelector: {}
 tolerations: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -60,10 +60,11 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
 
+# sideContainers is a list of containers that should run alongside the main container(s).
 sideContainers:
   # - name: sidecar
-  #   imagePullPolicy: Always
-  #   image: nginx:latest
+  #   image: busybox:latest
+  #   command: ["sleep", "infinity"]
   #   securityContext:
   #     privileged: true
   #   env:


### PR DESCRIPTION
This pull request includes changes to the Helm chart templates and values to support the addition of side containers. The most important changes include the addition of side container configurations and minor cleanups in the YAML files.

## Included PRs
- [#31](https://github.com/btungut/azure-devops-agent-on-kubernetes/pull/31) 

@saisona

### Support for side containers:

* [`chart/templates/deployment.yaml`](diffhunk://#diff-2c6c478bf17d4896de57d0def131d88f926a02e3a0159954b1e1457a19b78bebR31-R33): Added a section to include side containers in the deployment template.
* [`chart/values.yaml`](diffhunk://#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4R63-R80): Introduced a new `sideContainers` configuration to define side containers that should run alongside the main container.

### Minor cleanups:

* [`chart/values.yaml`](diffhunk://#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4L12): Removed unnecessary blank lines for better readability. [[1]](diffhunk://#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4L12) [[2]](diffhunk://#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4L53)