### PR TITLE
build: Refactor Dockerfile and local-build script to use build arguments for base image and agent version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
+ARG ARG_UBUNTU_BASE_IMAGE="ubuntu"
 ARG ARG_UBUNTU_BASE_IMAGE_TAG="20.04"
 
-FROM ubuntu:${ARG_UBUNTU_BASE_IMAGE_TAG}
+FROM ${ARG_UBUNTU_BASE_IMAGE}:${ARG_UBUNTU_BASE_IMAGE_TAG}
 WORKDIR /azp
-ENV TARGETARCH=linux-x64
-ENV VSTS_AGENT_VERSION=4.251.0
+ARG ARG_TARGETARCH=linux-x64
+ARG ARG_VSTS_AGENT_VERSION=4.251.0
 
 
 # To make it easier for build and release pipelines to run apt-get,
@@ -30,8 +31,8 @@ RUN apt-get update && apt-get -y upgrade
 
 # Download and extract the Azure DevOps Agent
 RUN printenv \
-    && echo "Downloading Azure DevOps Agent version ${VSTS_AGENT_VERSION} for ${TARGETARCH}"
-RUN curl -LsS https://vstsagentpackage.azureedge.net/agent/${VSTS_AGENT_VERSION}/vsts-agent-${TARGETARCH}-${VSTS_AGENT_VERSION}.tar.gz | tar -xz
+    && echo "Downloading Azure DevOps Agent version ${ARG_VSTS_AGENT_VERSION} for ${ARG_TARGETARCH}"
+RUN curl -LsS https://vstsagentpackage.azureedge.net/agent/${ARG_VSTS_AGENT_VERSION}/vsts-agent-${ARG_TARGETARCH}-${ARG_VSTS_AGENT_VERSION}.tar.gz | tar -xz
 
 
 

--- a/local-build.sh
+++ b/local-build.sh
@@ -4,7 +4,17 @@ set -euo pipefail
 REGISTRY="${REGISTRY:-btungut}"
 TAG="${TAG:-latest}"
 
+UBUNTU_BASE_IMAGE="${UBUNTU_BASE_IMAGE:-ubuntu}"
+UBUNTU_BASE_IMAGE_TAG="${UBUNTU_BASE_IMAGE_TAG:-20.04}"
+TARGETARCH="${TARGETARCH:-linux-x64}"
+VSTS_AGENT_VERSION="${VSTS_AGENT_VERSION:-4.251.0}"
+
 docker build ./src \
+    --build-arg ARG_UBUNTU_BASE_IMAGE=${UBUNTU_BASE_IMAGE} \
+    --build-arg ARG_UBUNTU_BASE_IMAGE_TAG=${UBUNTU_BASE_IMAGE_TAG} \
+    --build-arg ARG_TARGETARCH=${TARGETARCH} \
+    --build-arg ARG_VSTS_AGENT_VERSION=${VSTS_AGENT_VERSION} \
     -f ./Dockerfile \
     -t ${REGISTRY}/azure-devops-agent:${TAG} \
-    --progress=plain
+    --progress=plain \
+    "$@"


### PR DESCRIPTION
Introduces `ARG_UBUNTU_BASE_IMAGE`, `ARG_UBUNTU_BASE_IMAGE_TAG` , `ARG_TARGETARCH` and `ARG_VSTS_AGENT_VERSION` instead of hardcoding them. Also passes all arguments to the build script to `docker build` to enable passing additional arguments.

The main idea is that this can allow building a matrix of image variants for different Ubuntu flavours and tags, as well as AzDO agent version and architectures using the same Dockerfile and the same build script.

```bash
UBUNTU_BASE_IMAGE=my-ubuntu-image \
    UBUNTU_BASE_IMAGE_TAG=22.04 \
    VSTS_AGENT_VERSION=4.252.0 \
    ./local-build.sh \
    -t example
```