### PR TITLE
feat: Add `git-lfs` to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     git \
+    git-lfs \
     iputils-ping \
     jq \
     lsb-release \


### PR DESCRIPTION
`git lfs` is commonly used in CI/CD pipelines and should be available in all derived images.