### PR TITLE
Unset resource limits and requests

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -33,13 +33,16 @@ image:
   tag: "4.251.0-stable-v2.3.0"
   pullSecrets: []
 
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+
+### You can uncomment the following lines to set resource limits and requests for the agent container.
+### NOTE: Resource limits must be set according to your needs and the capabilities of your Kubernetes cluster!!!
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 volumes: []
   # - name: dockersock


### PR DESCRIPTION
This pull request modifies the `chart/values.yaml` file to make resource limits and requests configurable by commenting out the default settings and providing instructions for customization.

Configuration changes:

* [`chart/values.yaml`](diffhunk://#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4L36-R45): Replaced hardcoded `resources` limits and requests with a commented-out configuration block, allowing users to uncomment and customize these settings based on their Kubernetes cluster's needs. Added a note emphasizing the importance of setting resource limits appropriately.