### PR TITLE
fix: Update download URL of the Azure DevOps agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ RUN apt-get update && apt-get -y upgrade
 # Download and extract the Azure DevOps Agent
 RUN printenv \
     && echo "Downloading Azure DevOps Agent version ${ARG_VSTS_AGENT_VERSION} for ${ARG_TARGETARCH}"
-RUN curl -LsS https://vstsagentpackage.azureedge.net/agent/${ARG_VSTS_AGENT_VERSION}/vsts-agent-${ARG_TARGETARCH}-${ARG_VSTS_AGENT_VERSION}.tar.gz | tar -xz
-
+RUN curl -LsS https://download.agent.dev.azure.com/agent/${ARG_VSTS_AGENT_VERSION}/vsts-agent-${ARG_TARGETARCH}-${ARG_VSTS_AGENT_VERSION}.tar.gz | tar -xz
 
 
 # Install Azure CLI & Azure DevOps extension


### PR DESCRIPTION
https://vstsagentpackage.azureedge.net has been deprecated in favour of https://download.agent.dev.azure.com

Source: https://devblogs.microsoft.com/devops/cdn-domain-url-change-for-agents-in-pipelines/